### PR TITLE
nav: stick to window

### DIFF
--- a/src/components/JDNavigation/JDNavigation.astro
+++ b/src/components/JDNavigation/JDNavigation.astro
@@ -78,6 +78,12 @@ pages.sort(jdSort);
       padding: 0;
 
       border-top: none;
+
+      position: sticky;
+      top:0;
+      height: fit-content;
+      max-height: 100vh;
+      overflow-y: auto;
     }
 
     @include for-print {


### PR DESCRIPTION
The navigation bar takes up a lot of the horizontal space on >900px screens considering it scroll away immediately.

This fix changes the nav bar to stick to the top of the page as a user scrolls on wider screens (`for-tablet-landscape-up`). If the screen height is not tall enough to show it fully, the container gets a scrollbar.

## Current

> ![image](https://github.com/johnnydecimal/v5.johnnydecimal.com/assets/109556932/19e8b63c-195a-4322-893d-a83d6538d4d8)
> Scrolls off screen

> ![image](https://github.com/johnnydecimal/v5.johnnydecimal.com/assets/109556932/972831af-768c-42dd-b2c9-775140d5f238)
> Unaffected by short screens


## Proposed

> ![image](https://github.com/johnnydecimal/v5.johnnydecimal.com/assets/109556932/9db17052-78d5-4441-a604-6f7b4e0b11b8)
> Sticks to screen

> ![image](https://github.com/johnnydecimal/v5.johnnydecimal.com/assets/109556932/048fab6d-366e-40d8-befc-b151251a4135)
> Scrollbar for short screens
